### PR TITLE
Recoil기반 Data Fetch 및 상태관리 방식

### DIFF
--- a/components/DummyToRecoil.tsx
+++ b/components/DummyToRecoil.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect } from 'react';
+import { gql } from '@apollo/client';
+import client from '~/lib/apollo/client';
+import createLazyQuery from '~/lib/recoil/factories/createLazyQuery';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import browserOnly from '~/components/_common/hoc/browserOnly';
+
+/**
+ * @description
+ * 원래는 DummyToRecoilState.tsx 파일에 있어야 하는 부분
+ * 테스트를 위해 하나의 파일에서 작성
+ */
+const GET_SPOTS = gql`
+  query GetSpots {
+    getAllSpots {
+      id
+    }
+  }
+`;
+
+const { queryVariables, queryResult } = createLazyQuery<string[], null>(
+  {
+    key: 'DummyToRecoil',
+  },
+  async () => {
+    const response = await client.query({
+      query: GET_SPOTS,
+    });
+
+    return response?.data?.getAllSpots;
+  }
+);
+
+/**
+ * @description
+ * query를 요청하는 컴포넌트 (즉, 쿼리 결과를 변화시키는 컴포넌트)
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const DummyToRecoilRequest: React.FC = () => {
+  const request = useSetRecoilState(queryVariables);
+
+  useEffect(() => {
+    request(null);
+  }, []);
+
+  return <></>;
+};
+
+/**
+ * @description
+ * query 결과를 받는 컴포넌트
+ */
+const DummyToRecoilResult: React.FC = () => {
+  const result = useRecoilValue(queryResult);
+
+  console.log('<===== DummyToRecoil 응답값 =====>');
+  console.log(result);
+
+  return <></>;
+};
+
+/**
+ * @description
+ * (이부분 조금 더 리서치 해봐야하는 부분이긴 한데)
+ * recoil이 Suspense intergration 에 적합하도록 개발되어 있는듯 함.
+ * 그래서 항상, React.Suspense가 필요할듯
+ */
+const DummyToRecoil: React.FC = () => {
+  return (
+    <>
+      {/* 지금은 variables가 필요없어서, DummyToRecoilRequests가 없어도 됨 */}
+      <React.Suspense fallback={<></>}>
+        <DummyToRecoilResult />
+      </React.Suspense>
+    </>
+  );
+};
+
+/**
+ * TODO: recoil 상태 hydration 처리에 대해 알아봐야함.
+ * 일단은 CSR만 가능한듯
+ */
+export default browserOnly(DummyToRecoil);

--- a/lib/recoil/factories/createLazyQuery.ts
+++ b/lib/recoil/factories/createLazyQuery.ts
@@ -1,0 +1,93 @@
+import {
+  atom,
+  RecoilState,
+  RecoilValueReadOnly,
+  selector,
+  selectorFamily,
+} from 'recoil';
+import type { SerializableParam } from 'recoil';
+
+type RecoilOption = {
+  key: string;
+};
+
+type Fetcher<ResponseData = any, Variables extends SerializableParam = any> = (
+  variables: Variables
+) => Promise<ResponseData>;
+
+type LazyQueryRecoils<
+  ResponseData = any,
+  Variables extends SerializableParam = any
+> = {
+  query: (varaibles: Variables) => RecoilValueReadOnly<ResponseData>;
+  queryVariables: RecoilState<Variables>;
+  queryResult: RecoilValueReadOnly<ResponseData>;
+};
+
+/**
+ * @description
+ * Recoil Key Naming Rule
+ * - TODO: memoize
+ */
+const nameQueryKey = (queryKey: string) => queryKey;
+const nameCurrentQueryKey = (queryKey: string) => {
+  const key = nameQueryKey(queryKey);
+
+  return `Current${key[0].toUpperCase()}${key.substr(1)}`;
+};
+const nameCurrentStateKey = (queryKey: string) => {
+  const key = nameCurrentQueryKey(queryKey);
+
+  return `${key}State`;
+};
+
+/**
+ * @description
+ * fetch 기반으로 lazyQuery 노드들을 생성해주는 Factory 함수
+ * - Base Flow : https://recoiljs.org/docs/guides/asynchronous-data-queries#data-flow-graph
+ */
+const createLazyQueryRecoils = <
+  ResponseData,
+  Variables extends SerializableParam = any
+>(
+  option: RecoilOption,
+  fetcher: Fetcher<ResponseData, Variables>
+): LazyQueryRecoils => {
+  const queryKey: string = nameQueryKey(option.key);
+  const currentQueryKey = nameCurrentQueryKey(option.key);
+  const currentStateKey = nameCurrentStateKey(option.key);
+
+  const query = selectorFamily<ResponseData, Variables>({
+    key: queryKey,
+    get: (variables: Variables) => async () => {
+      try {
+        console.log(`<fetch> ${queryKey}`);
+        const response: ResponseData = await fetcher(variables);
+
+        return response;
+      } catch (err) {
+        // TODO: error pipeline
+      }
+
+      return null;
+    },
+  });
+
+  const currentState = atom<Variables>({
+    key: currentStateKey,
+    default: null,
+  });
+
+  const currentQuery = selector<ResponseData>({
+    key: currentQueryKey,
+    get: ({ get }) => get(query(get(currentState))),
+  });
+
+  return {
+    query,
+    queryVariables: currentState,
+    queryResult: currentQuery,
+  };
+};
+
+export default createLazyQueryRecoils;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Head from 'next/head';
 import styles from '../styles/Home.module.css';
 import MainPage from '../components/Home/MainMapPage/MainPage';
+import DummyToRecoil from '~/components/DummyToRecoil';
 
 const Home: React.FC = () => {
   return (
@@ -14,6 +15,8 @@ const Home: React.FC = () => {
       <main className={styles.main}>
         <MainPage />
       </main>
+
+      <DummyToRecoil />
 
       <footer className={styles.footer}>
         <a


### PR DESCRIPTION
## 내용 

`recoil` 기반에서 `API fetching`을 다룰 때 가장 범용성 있는 노드 구조라고 생각되어 이 형태로 만들어봄
(더 좋은 방식이 뭐가 있을지 계속 고민해봐야할 듯)

- 세가지 노드
    - 상태변화를 trigger 시킬 노드
    - 상태변화를 받아서 `fetch`할 노드
    - `fetch`결과를 상태로 관리할 노드
- 참고 URL
    - https://recoiljs.org/docs/guides/asynchronous-data-queries#data-flow-graph

## 더 찾아봐야할 내용

- `recoil`에서 [React.Suspense](https://reactjs.org/docs/concurrent-mode-suspense.html)를 활용하는 방식에 대해 조금 더 찾아봐야할 것 같아.
    -`React.Suspense`를 이번에 처음 사용해봐서 아직 잘 모르는데, `recoil`이 해당 인터페이스에 최적화되게 설계된 것 같음
    - 지금까지 구현하면서 느낀점은, 기존(`redux, mobx, apollo-client`)에는 비동기 사이클이 컴포넌트 라이프사이클에 의존적으로 동작했다면, 컴포넌트 외부로 의존성 분리를 한 것 같음. (어떻게 했는지는 라이브러리를 조금 살펴봐야 할듯..)