### PR TITLE
styled-components 테마기능 추가

### DIFF
--- a/@types/theme.d.ts
+++ b/@types/theme.d.ts
@@ -1,0 +1,41 @@
+import 'styled-components';
+
+declare module 'styled-components' {
+  /**
+   * @see figma 사이드바 > inspect 탭에서 확인 가능
+   */
+  export interface DefaultTheme {
+    primary: {
+      basic: string;
+      light: string;
+      dark: string;
+    };
+    secondary: {
+      sugar0: string;
+      sugar30: string;
+      sugar50: string;
+      sugar70: string;
+      sugar100: string;
+    };
+    basic: {
+      black: string;
+      white: string;
+    };
+    grayscale: {
+      '1': string;
+      '2': string;
+      '3': string;
+      '4': string;
+      '5': string;
+      '6': string;
+      '7': string;
+      '8': string;
+      '9': string;
+      '10': string;
+    };
+    system: {
+      error: string;
+      positive: string;
+    };
+  }
+}

--- a/components/Popup/SpotGenerator/AreaEmoji/AreaEmoji.tsx
+++ b/components/Popup/SpotGenerator/AreaEmoji/AreaEmoji.tsx
@@ -28,9 +28,7 @@ const AreaEmoji: React.FC = () => {
             {emoji && (
               <$.EmojiButton
                 onClick={(e) => handleClickEmoji(e, emoji.id)}
-                style={{
-                  transform: emoji.id === selectedEmoji ? 'scale(1.3)' : '',
-                }}
+                aria-selected={emoji.id === selectedEmoji}
               >
                 <$.EmojiImage src={emoji.imageUrl} />
               </$.EmojiButton>

--- a/components/Popup/SpotGenerator/AreaEmoji/AreaEmojiView.tsx
+++ b/components/Popup/SpotGenerator/AreaEmoji/AreaEmojiView.tsx
@@ -12,28 +12,43 @@ export const EmojiList = styled.ul`
   flex-direction: row;
   flex-wrap: wrap;
   justify-content: center;
-  margin-top: 2.5rem;
+  margin-top: 40px;
 `;
 
 export const EmojiItem = styled.li`
   flex-shrink: 0;
   flex-grow: 0;
   &:nth-child(n + 5) {
-    margin-top: 2rem;
+    margin-top: 32px;
   }
   &:nth-child(4n + 2),
   &:nth-child(4n + 3),
   &:nth-child(4n + 4) {
-    margin-left: 3rem;
+    margin-left: 48px;
   }
-  width: 4rem;
-  height: 4rem;
+  width: 64px;
+  height: 64px;
 `;
 
 export const EmojiButton = styled.a.attrs({ href: '#', role: 'button' })`
   display: block;
-  width: 4rem;
-  height: 4rem;
+  position: relative;
+  width: 64px;
+  height: 64px;
+  ${(props) =>
+    props['aria-selected'] &&
+    `
+  &::after {
+    content: '';
+    position: absolute;
+    top: -10px;
+    right: -10px;
+    bottom: -10px;
+    left: -10px;
+    border: 5px solid ${props.theme.primary.basic};
+    border-radius: 50%;
+  }
+  `}
 `;
 
 export const EmojiImage = styled.img.attrs({ width: '64', height: '64' })`

--- a/components/Popup/SpotGenerator/AreaFilter/AreaFilter.tsx
+++ b/components/Popup/SpotGenerator/AreaFilter/AreaFilter.tsx
@@ -1,24 +1,41 @@
 import React from 'react';
-import moods from '~/constants/moods';
 import * as $ from './AreaFilterView';
 
 const AreaFilter: React.FC = () => {
-  const handleClickMood = (e) => {
+  const handleClickSugar = (e) => {
     e.preventDefault();
-    // TODO: 무드 필터링 기능
+    // TODO: 당도 필터링 기능
   };
 
   return (
     <$.AreaFilter>
-      <$.MoodList>
-        {moods.map((mood, i) => (
-          <$.MoodItem key={`mood-button-${i}`}>
-            <$.MoodButton color={mood.color} onClick={handleClickMood}>
-              {mood.label}
-            </$.MoodButton>
-          </$.MoodItem>
-        ))}
-      </$.MoodList>
+      <$.SugarList>
+        <$.SugarItem>
+          <$.SugarButton color="sugar0" onClick={handleClickSugar}>
+            당도 0%
+          </$.SugarButton>
+        </$.SugarItem>
+        <$.SugarItem>
+          <$.SugarButton color="sugar30" onClick={handleClickSugar}>
+            30%
+          </$.SugarButton>
+        </$.SugarItem>
+        <$.SugarItem>
+          <$.SugarButton color="sugar50" onClick={handleClickSugar}>
+            50%
+          </$.SugarButton>
+        </$.SugarItem>
+        <$.SugarItem>
+          <$.SugarButton color="sugar70" onClick={handleClickSugar}>
+            70%
+          </$.SugarButton>
+        </$.SugarItem>
+        <$.SugarItem>
+          <$.SugarButton color="sugar100" onClick={handleClickSugar}>
+            100%
+          </$.SugarButton>
+        </$.SugarItem>
+      </$.SugarList>
     </$.AreaFilter>
   );
 };

--- a/components/Popup/SpotGenerator/AreaFilter/AreaFilterView.tsx
+++ b/components/Popup/SpotGenerator/AreaFilter/AreaFilterView.tsx
@@ -1,32 +1,35 @@
 import React from 'react';
 import styled from 'styled-components';
+import painter from '~/styles/theme/painter';
 
 export const AreaFilter = styled.div`
   flex-grow: 0;
   flex-shrink: 0;
 `;
 
-export const MoodList = styled.ul`
-  margin-top: 1.875rem;
+export const SugarList = styled.ul`
+  margin-top: 30px;
   font-size: 0;
+  white-space: nowrap;
 `;
 
-export const MoodItem = styled.li`
+export const SugarItem = styled.li`
   display: inline-block;
   vertical-align: top;
   & + & {
-    margin-left: 0.75rem;
+    margin-left: 8px;
   }
 `;
 
-export const MoodButton = styled.a.attrs({ href: '#', role: 'button' })`
+export const SugarButton = styled.a.attrs({ href: '#', role: 'button' })`
   display: block;
-  height: 2.5rem;
-  border-radius: 1.25rem;
-  border: 0.0625rem solid #d0d0d0;
-  padding: 0 1.25rem;
-  font-size: 1rem;
-  line-height: ${2.5 - 0.0625}rem;
-  background-color: #fff;
-  color: ${(props) => props.color};
+  height: 42px;
+  border-radius: 21px;
+  border: 1px solid #d0d0d0;
+  padding: 12px 16px 12px 20px;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 16px;
+  background-color: ${painter.basic.white};
+  color: ${(props) => painter.secondary[props.color]};
 `;

--- a/components/Popup/SpotGenerator/AreaForm/AreaFormView.tsx
+++ b/components/Popup/SpotGenerator/AreaForm/AreaFormView.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import painter from '~/styles/theme/painter';
 
 export const AreaForm = styled.div`
   flex-shrink: 0;
@@ -8,11 +9,12 @@ export const AreaForm = styled.div`
 
 export const SubmitButton = styled.a.attrs({ href: '#', role: 'button' })`
   display: block;
-  height: 4rem;
-  border-radius: 0.75rem;
+  height: 64px;
+  border-radius: 12px;
   background-color: #101721;
-  font-size: 1.25rem;
-  line-height: 4rem;
+  font-weight: bold;
+  font-size: 20px;
+  line-height: 64px;
   text-align: center;
-  color: #fff;
+  color: ${painter.basic.white};
 `;

--- a/components/Popup/SpotGenerator/SpotGeneratorView.tsx
+++ b/components/Popup/SpotGenerator/SpotGeneratorView.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import painter from '~/styles/theme/painter';
 
 export const SpotGenerator = styled.div<{ zIndex: string }>`
   position: fixed;
@@ -7,18 +8,18 @@ export const SpotGenerator = styled.div<{ zIndex: string }>`
   top: 0;
   right: 0;
   bottom: 0;
-  width: 31.25rem;
-  border-top-left-radius: 2.5rem;
-  box-shadow: 0 0 0.75rem 0.13rem #ddd;
-  background-color: #f6f8f9;
+  width: 500px;
+  border-top-left-radius: 40px;
+  box-shadow: 0 0 14px 1px ${painter.grayscale['6']};
+  background-color: ${painter.grayscale['10']};
 `;
 
 export const Inner = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: calc(100% - 7rem);
-  padding: 2.5rem 2rem 3rem;
+  height: calc(100% - 112px);
+  padding: 40px 32px 48px;
 `;
 
 export const AreaText = styled.div`
@@ -28,13 +29,14 @@ export const AreaText = styled.div`
 
 export const HelpTitle = styled.strong`
   display: block;
-  font-size: 1.5rem;
-  color: #666;
+  font-size: 24px;
+  line-height: 25px;
+  color: ${painter.grayscale['2']};
 `;
 
 export const HelpText = styled.p`
-  margin-top: 0.5rem;
-  padding-left: 0.2rem;
-  font-size: 1.125rem;
-  color: #a6a6a6;
+  margin-top: 4px;
+  font-size: 18px;
+  line-height: 25px;
+  color: ${painter.grayscale['5']};
 `;

--- a/components/Popup/SpotGenerator/Title/TitleView.tsx
+++ b/components/Popup/SpotGenerator/Title/TitleView.tsx
@@ -1,26 +1,28 @@
 import React from 'react';
 import styled from 'styled-components';
+import painter from '~/styles/theme/painter';
 
 export const Title = styled.div`
   position: relative;
-  height: 7rem;
-  border-top-left-radius: 2.5rem;
-  background-color: #01e3ab;
+  height: 112px;
+  border-top-left-radius: 40px;
+  background-color: ${painter.primary.basic};
 `;
 
 export const Text = styled.h3`
-  padding-left: 2.5rem;
-  font-size: 2rem;
-  line-height: 7rem;
-  color: #fff;
+  padding-left: 40px;
+  font-weight: normal;
+  font-size: 32px;
+  line-height: 112px;
+  color: ${painter.basic.white};
 `;
 
-export const CloseLayerButton = styled.a`
+export const CloseLayerButton = styled.a.attrs({ href: '#', role: 'button' })`
   position: absolute;
   top: 0;
   right: 0;
-  width: 7rem;
-  height: 7rem;
+  width: 112px;
+  height: 112px;
   outline: none;
   cursor: pointer;
   &::before,
@@ -31,10 +33,10 @@ export const CloseLayerButton = styled.a`
     right: 0;
     bottom: 0;
     left: 0;
-    width: 1.68rem;
-    height: 0.18rem;
+    width: 27px;
+    height: 3px;
     margin: auto;
-    background-color: #fff;
+    background-color: ${painter.basic.white};
   }
   &::before {
     transform: rotate(45deg);

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,17 +1,21 @@
 import { ApolloProvider } from '@apollo/client';
 import { RecoilRoot } from 'recoil';
 import apolloClient from '../lib/apollo/client';
+import theme from '../styles/theme';
 import '../styles/reset.css';
 import '../styles/globals.css';
 import type { AppProps } from 'next/app';
+import { ThemeProvider } from 'styled-components';
 
 const App: React.FC<AppProps> = ({ Component, pageProps }) => {
   return (
-    <ApolloProvider client={apolloClient}>
-      <RecoilRoot>
-        <Component {...pageProps} />
-      </RecoilRoot>
-    </ApolloProvider>
+    <ThemeProvider theme={theme}>
+      <ApolloProvider client={apolloClient}>
+        <RecoilRoot>
+          <Component {...pageProps} />
+        </RecoilRoot>
+      </ApolloProvider>
+    </ThemeProvider>
   );
 };
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Head from 'next/head';
-import styles from '../styles/Home.module.css';
 import MainPage from '../components/Home/MainMapPage/MainPage';
+import styles from '../styles/Home.module.css';
 
 const Home: React.FC = () => {
   return (

--- a/styles/theme/index.ts
+++ b/styles/theme/index.ts
@@ -1,0 +1,1 @@
+export { default } from './theme';

--- a/styles/theme/painter.ts
+++ b/styles/theme/painter.ts
@@ -1,0 +1,61 @@
+import { DefaultTheme } from 'styled-components';
+
+type ImportColor = (props: {
+  theme: DefaultTheme;
+  [key: string]: any;
+}) => string;
+
+type ThemePainter<Theme> = {
+  [key in keyof Theme]: ImportColor;
+};
+
+type Painter = {
+  primary: ThemePainter<DefaultTheme['primary']>;
+  secondary: ThemePainter<DefaultTheme['secondary']>;
+  basic: ThemePainter<DefaultTheme['basic']>;
+  grayscale: ThemePainter<DefaultTheme['grayscale']>;
+  system: ThemePainter<DefaultTheme['system']>;
+};
+
+/**
+ * @description theme를 props에서 가져오는 함수
+ * @see
+ * - color 가져올때마다 새로운 함수를 계속 만들면 불필요하게 메모리를 많이 먹을 것 같아서 사용
+ * - props 에 따른 분기처리 할땐 컴포넌트 내에서 함수 만들어서 사용해도 무방할 듯
+ */
+const painter: Painter = {
+  primary: {
+    basic: (props) => props.theme.primary.basic,
+    light: (props) => props.theme.primary.light,
+    dark: (props) => props.theme.primary.dark,
+  },
+  secondary: {
+    sugar0: (props) => props.theme.secondary.sugar0,
+    sugar30: (props) => props.theme.secondary.sugar30,
+    sugar50: (props) => props.theme.secondary.sugar50,
+    sugar70: (props) => props.theme.secondary.sugar70,
+    sugar100: (props) => props.theme.secondary.sugar100,
+  },
+  basic: {
+    black: (props) => props.theme.basic.black,
+    white: (props) => props.theme.basic.white,
+  },
+  grayscale: {
+    '1': (props) => props.theme.grayscale['1'],
+    '2': (props) => props.theme.grayscale['2'],
+    '3': (props) => props.theme.grayscale['3'],
+    '4': (props) => props.theme.grayscale['4'],
+    '5': (props) => props.theme.grayscale['5'],
+    '6': (props) => props.theme.grayscale['6'],
+    '7': (props) => props.theme.grayscale['7'],
+    '8': (props) => props.theme.grayscale['8'],
+    '9': (props) => props.theme.grayscale['9'],
+    '10': (props) => props.theme.grayscale['10'],
+  },
+  system: {
+    error: (props) => props.theme.system.error,
+    positive: (props) => props.theme.system.positive,
+  },
+};
+
+export default painter;

--- a/styles/theme/theme.ts
+++ b/styles/theme/theme.ts
@@ -1,0 +1,38 @@
+import type { DefaultTheme } from 'styled-components';
+
+const theme: DefaultTheme = {
+  primary: {
+    basic: '#FD476D',
+    light: '#FE91A7',
+    dark: '#E94164',
+  },
+  secondary: {
+    sugar0: '#43B1FE',
+    sugar30: '#37F4BC',
+    sugar50: '#FBFE6B',
+    sugar70: '#FF7759',
+    sugar100: '#8E61FA',
+  },
+  basic: {
+    black: '#000',
+    white: '#fff',
+  },
+  grayscale: {
+    '1': '#212121',
+    '2': '#343A40',
+    '3': '#495057',
+    '4': '#868E96',
+    '5': '#ADB5BD',
+    '6': '#CED4DA',
+    '7': '#DEE2E6',
+    '8': '#E9ECEF',
+    '9': '#F1F3F5',
+    '10': '#F8F9FA',
+  },
+  system: {
+    error: '#FF5B5B',
+    positive: '#36D789',
+  },
+};
+
+export default theme;


### PR DESCRIPTION
## 요약

보은이와 색상값 협의해서 `styled-components`의 테마기능으로 구현해뒀어.
색상 사용시, `~/styles/theme/painter.ts`를 이용하거나, 직접 props에서 가져오면 될듯 함.
(자세한 부분은 소스코드 참고)

## 내용

- `styled-components` 테마 기능 추가
- `Mood`에서 `Sugar`로 네이밍 변경
- `rem` 단위 `px` 단위로 모두 변경