### PR TITLE
코스 히스토리/에디터 레이아웃 추가 및 GNB 변경된 디자인 적용

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["next/babel"]
+  "presets": ["next/babel"],
+  "plugins": [["styled-components", { "ssr": true }]]
 }

--- a/components/Course/CourseView.tsx
+++ b/components/Course/CourseView.tsx
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+import painter from '~/styles/theme/painter';
+
+export const Wrap = styled.div`
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  &::after {
+    content: '';
+    display: block;
+    clear: both;
+  }
+`;
+
+export const Sidebar = styled.div`
+  flex-grow: 0;
+  flex-shrink: 0;
+  width: 452px;
+  height: 100%;
+  padding-top: 80px;
+  background-color: ${painter.basic.white};
+`;
+
+export const Content = styled.div`
+  overflow: auto;
+  width: 100%;
+  height: 100%;
+  background-color: ${painter.grayscale[1]};
+`;
+
+export const ContentInner = styled.div`
+  position: relative;
+  min-width: 916px;
+  height: 100%;
+`;

--- a/components/Course/Editor/CandidateSpots/CandidateSpots.tsx
+++ b/components/Course/Editor/CandidateSpots/CandidateSpots.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import * as $ from './CandidateSpotsView';
+
+const CandidateSpots: React.FC = () => {
+  return <$.CandidateSpots></$.CandidateSpots>;
+};
+
+export default CandidateSpots;

--- a/components/Course/Editor/CandidateSpots/CandidateSpotsView.tsx
+++ b/components/Course/Editor/CandidateSpots/CandidateSpotsView.tsx
@@ -1,0 +1,3 @@
+import styled from 'styled-components';
+
+export const CandidateSpots = styled.div``;

--- a/components/Course/Editor/CandidateSpots/index.tsx
+++ b/components/Course/Editor/CandidateSpots/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './CandidateSpots';

--- a/components/Course/Editor/Editor.tsx
+++ b/components/Course/Editor/Editor.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import CandidateSpots from './CandidateSpots';
+import Preview from './Preview';
+import CourseTab from '~/components/Course/Tab';
+import {
+  Wrap,
+  Sidebar,
+  Content,
+  ContentInner,
+} from '~/components/Course/CourseView';
+
+const Editor: React.FC = () => {
+  return (
+    <Wrap>
+      <Sidebar>
+        <CandidateSpots />
+      </Sidebar>
+      <Content>
+        <ContentInner>
+          <CourseTab />
+          <Preview />
+        </ContentInner>
+      </Content>
+    </Wrap>
+  );
+};
+
+export default Editor;

--- a/components/Course/Editor/Preview/Preview.tsx
+++ b/components/Course/Editor/Preview/Preview.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import * as $ from './PreviewView';
+
+const Preview: React.FC = () => {
+  return <$.Preview></$.Preview>;
+};
+
+export default Preview;

--- a/components/Course/Editor/Preview/PreviewView.tsx
+++ b/components/Course/Editor/Preview/PreviewView.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const Preview = styled.div`
+  overflow: hidden;
+  position: relative;
+  height: 100%;
+`;

--- a/components/Course/Editor/Preview/index.tsx
+++ b/components/Course/Editor/Preview/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Preview';

--- a/components/Course/Editor/index.ts
+++ b/components/Course/Editor/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Editor';

--- a/components/Course/History/History.tsx
+++ b/components/Course/History/History.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import CourseTab from '~/components/Course/Tab';
+import {
+  Wrap,
+  Sidebar,
+  Content,
+  ContentInner,
+} from '~/components/Course/CourseView';
+
+const History: React.FC = () => {
+  return (
+    <Wrap>
+      <Sidebar></Sidebar>
+      <Content>
+        <ContentInner>
+          <CourseTab />
+        </ContentInner>
+      </Content>
+    </Wrap>
+  );
+};
+
+export default History;

--- a/components/Course/History/index.ts
+++ b/components/Course/History/index.ts
@@ -1,0 +1,1 @@
+export { default } from './History';

--- a/components/Course/Tab/Tab.tsx
+++ b/components/Course/Tab/Tab.tsx
@@ -19,8 +19,8 @@ const Tab: React.FC = () => {
           </Link>
         </$.TabItem>
         <$.TabItem>
-          <Link href="/course/create">
-            <$.TabLink aria-selected={secondPath === 'create'}>
+          <Link href="/course/editor">
+            <$.TabLink aria-selected={secondPath === 'editor'}>
               코스 만들기
             </$.TabLink>
           </Link>

--- a/components/Course/Tab/TabView.tsx
+++ b/components/Course/Tab/TabView.tsx
@@ -3,7 +3,8 @@ import painter from '~/styles/theme/painter';
 
 export const Tab = styled.div`
   position: absolute;
-  top: 34px;
+  z-index: 1;
+  top: 56px;
   left: 50%;
   width: 268px;
   margin-left: -133px;

--- a/components/Course/Wrap/Wrap.tsx
+++ b/components/Course/Wrap/Wrap.tsx
@@ -1,3 +1,0 @@
-import * as $ from './WrapView';
-
-export default $.Wrap;

--- a/components/Course/Wrap/WrapView.tsx
+++ b/components/Course/Wrap/WrapView.tsx
@@ -1,7 +1,0 @@
-import styled from 'styled-components';
-import painter from '~/styles/theme/painter';
-
-export const Wrap = styled.div`
-  height: 100%;
-  background-color: ${painter.grayscale[1]};
-`;

--- a/components/Course/Wrap/index.ts
+++ b/components/Course/Wrap/index.ts
@@ -1,1 +1,0 @@
-export { default } from './Wrap';

--- a/components/_assets/gnb/CourseIcon.tsx
+++ b/components/_assets/gnb/CourseIcon.tsx
@@ -7,8 +7,8 @@ type Props = {
 const CourseIcon: React.FC<Props> = ({ className }) => {
   return (
     <svg
-      width="40"
-      height="40"
+      width="32"
+      height="32"
       viewBox="0 0 40 40"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/components/_assets/gnb/SettingIcon.tsx
+++ b/components/_assets/gnb/SettingIcon.tsx
@@ -7,8 +7,8 @@ type Props = {
 const SettingIcon: React.FC<Props> = ({ className }) => {
   return (
     <svg
-      width="40"
-      height="40"
+      width="32"
+      height="32"
       viewBox="0 0 40 40"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/components/_assets/gnb/SpotIcon.tsx
+++ b/components/_assets/gnb/SpotIcon.tsx
@@ -7,8 +7,8 @@ type Props = {
 const SpotIcon: React.FC<Props> = ({ className }) => {
   return (
     <svg
-      width="40"
-      height="40"
+      width="32"
+      height="32"
       viewBox="0 0 40 40"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/components/_layout/GNB/GNBView.tsx
+++ b/components/_layout/GNB/GNBView.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import styled from 'styled-components';
+import painter from '~/styles/theme/painter';
 
 export const GNB = styled.div`
-  float: left;
-  width: 96px;
+  position: fixed;
+  z-index: 10000;
+  top: 0;
+  left: 0;
+  width: 72px;
   height: 100vh;
+  border-right: 1px solid ${painter.grayscale[3]};
+  box-shadow: 0 0 8px 1px ${painter.grayscale[4]};
+  background-color: ${painter.basic.white};
 `;
 
 export const GNBInner = styled.div`
@@ -14,7 +21,6 @@ export const GNBInner = styled.div`
   width: 100%;
   height: 100%;
   padding: 184px 0 50px;
-  background-color: rgba(0, 0, 0, 0.04);
 `;
 
 export const GNBLink = styled.a`
@@ -36,8 +42,8 @@ export const IconImg = (
   isSelected: boolean;
 }>`
   display: inline-block;
-  width: 40px;
-  height: 40px;
+  width: 32px;
+  height: 32px;
   vertical-align: top;
   color: ${(props) =>
     props.isSelected ? props.theme.primary.basic : props.theme.grayscale[5]};
@@ -47,6 +53,6 @@ export const IconText = styled.div<{ isSelected: boolean }>`
   margin-top: 4px;
   color: ${(props) =>
     !props.isSelected ? props.theme.grayscale[5] : props.theme.primary.basic};
-  font-size: 14px;
+  font-size: 12px;
   font-weight: normal;
 `;

--- a/components/_layout/Main.tsx
+++ b/components/_layout/Main.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import styled from 'styled-components';
 
 const Main = styled.div`
-  overflow: hidden;
+  width: 100%;
   height: 100vh;
+  padding-left: 72px;
 `;
 
 export default Main;

--- a/components/_layout/Wrap.tsx
+++ b/components/_layout/Wrap.tsx
@@ -4,6 +4,11 @@ import styled from 'styled-components';
 const Wrap = styled.div`
   width: 100vw;
   height: 100vh;
+  &::after {
+    content: '';
+    display: block;
+    clear: both;
+  }
 `;
 
 export default Wrap;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/styled-components": "^5.1.7",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "babel-plugin-styled-components": "^1.12.0",
     "eslint": "^7.17.0",
     "eslint-config-prettier": "^7.1.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",

--- a/pages/course/editor.tsx
+++ b/pages/course/editor.tsx
@@ -3,8 +3,7 @@ import Head from 'next/head';
 import GNB from '~/components/_layout/GNB';
 import Wrap from '~/components/_layout/Wrap';
 import Main from '~/components/_layout/Main';
-import CourseTab from '~/components/Course/Tab';
-import CourseWrap from '~/components/Course/Wrap';
+import CourseEditor from '~/components/Course/Editor';
 import { addApolloState, initializeApollo } from '~/lib/apollo/client';
 import type { GetStaticProps } from 'next';
 
@@ -17,7 +16,7 @@ export const getStaticProps: GetStaticProps = async () => {
   });
 };
 
-const CoursePage: React.FC = () => {
+const CourseEditorPage: React.FC = () => {
   return (
     <>
       <Head>
@@ -27,12 +26,11 @@ const CoursePage: React.FC = () => {
       <Wrap>
         <GNB />
         <Main>
-          <CourseTab />
-          <CourseWrap />
+          <CourseEditor />
         </Main>
       </Wrap>
     </>
   );
 };
 
-export default CoursePage;
+export default CourseEditorPage;

--- a/pages/course/history.tsx
+++ b/pages/course/history.tsx
@@ -3,8 +3,7 @@ import Head from 'next/head';
 import GNB from '~/components/_layout/GNB';
 import Wrap from '~/components/_layout/Wrap';
 import Main from '~/components/_layout/Main';
-import CourseTab from '~/components/Course/Tab';
-import CourseWrap from '~/components/Course/Wrap';
+import CourseHistory from '~/components/Course/History';
 import { addApolloState, initializeApollo } from '~/lib/apollo/client';
 import type { GetStaticProps } from 'next';
 
@@ -17,7 +16,7 @@ export const getStaticProps: GetStaticProps = async () => {
   });
 };
 
-const CoursePage: React.FC = () => {
+const CourseHistoryPage: React.FC = () => {
   return (
     <>
       <Head>
@@ -27,12 +26,11 @@ const CoursePage: React.FC = () => {
       <Wrap>
         <GNB />
         <Main>
-          <CourseTab />
-          <CourseWrap />
+          <CourseHistory />
         </Main>
       </Wrap>
     </>
   );
 };
 
-export default CoursePage;
+export default CourseHistoryPage;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,6 +6,10 @@ body {
   line-height: 1.2;
 }
 
+body {
+  background-color: #F8F9FA;
+}
+
 a {
   color: inherit;
   text-decoration: none;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1001,7 +1001,7 @@ axobject-query@^2.2.0:
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
   integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
 
-"babel-plugin-styled-components@>= 1":
+"babel-plugin-styled-components@>= 1", babel-plugin-styled-components@^1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.12.0.tgz#1dec1676512177de6b827211e9eda5a30db4f9b9"
   integrity sha512-FEiD7l5ZABdJPpLssKXjBUJMYqzbcNzBowfXDCdJhOpbhWiewapUaY+LZGT8R4Jg2TwOjGjG4RKeyrO5p9sBkA==


### PR DESCRIPTION
## 내용

- 코스 히스토리/에디터 레이아웃 추가
- GNB 변경된 디자인 적용
- 라우팅 변경 `course/create` => `course/editor`