### PR TITLE
렌더링 서버 인프라 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+.certs
+
 # dependencies
 /node_modules
 /.pnp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:14.15.4-alpine3.11
+
+WORKDIR /usr/daedong
+RUN npm install --global pm2
+COPY ./package.json ./
+COPY ./yarn.lock ./
+RUN yarn
+COPY ./ ./
+
+RUN yarn build
+EXPOSE 3000
+
+# node:14.15.4-alpine3.11 에 등록된 기본 유저
+USER node
+
+CMD [ "pm2-runtime", "npm", "--", "start" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  daedong:
+    build: ./
+  nginx:
+    build: ./nginx
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - ./nginx/.certs:/etc/ssl/certs

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,12 @@
+FROM nginx:1.19.6-alpine
+
+# nginx 설정파일 교체
+RUN mkdir -p /etc/ssl/certs
+RUN rm /etc/nginx/conf.d/*
+
+COPY ./.certs/fullchain.pem /etc/ssl/certs/
+COPY ./.certs/privkey.pem /etc/ssl/certs/
+COPY ./default.conf /etc/nginx/conf.d/
+
+EXPOSE 443
+CMD [ "nginx", "-g", "daemon off;" ]

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,69 @@
+# static 파일 캐시설정
+# - 서브디렉토리에 md5 해시로 파일이름 설정
+# - STATIC 메모리존 10MB
+# - 60분 후 캐시 삭제
+# - 데이터 사본 방지
+proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=STATIC:10m inactive=60m use_temp_path=off;
+
+# UPSTREAM 설정 : 추후 로드밸런싱 대비
+upstream daedong_upstream {
+  server daedong:3000;
+}
+
+# HTTP 서버 설정
+server {
+    listen 80;
+    server_name daedongyeomap.com;
+    root html;
+
+    location / {
+        return 301 https://$server_name$request_uri;
+    }
+}
+
+# HTTPS 서버 설정
+server {
+  listen 443 ssl;
+  server_name daedongyeomap.com;
+  server_tokens off; # nginx 버전을 응답에 명시하지 않음 (for 보안)
+
+  # SSL 설정
+  ssl_certificate /etc/ssl/certs/fullchain.pem;
+  ssl_certificate_key /etc/ssl/certs/privkey.pem;
+  ssl_session_timeout 5m; # 세션 타임아웃 설정
+  ssl_protocols TLSv1.2 TLSv1.3; # 보안성을 위해 TLSv1.2 이상 프로토콜을 사용해야한다고 함 (Nginx 가이드)
+  ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH"; # 보안 알고리즘 강화 (정확히 어떤 알고리즘인지는 잘 모름)
+  ssl_prefer_server_ciphers on;
+
+  # gzip 설정
+  gzip on;
+  gzip_proxied any;
+  gzip_comp_level 4;
+  gzip_types text/css application/javascript image/svg+xml;
+
+  # 프록시 설정
+  proxy_http_version 1.1;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection 'upgrade';
+  proxy_set_header Host $host;
+  proxy_cache_bypass $http_upgrade;
+
+  # nextjs 의 static 파일 프록시 설정
+  location /_next/static {
+    proxy_cache STATIC;
+    proxy_pass http://daedong_upstream;
+  }
+
+  # 우리가 등록한 static 파일 프록시 설정
+  location /public {
+    proxy_cache STATIC;
+    proxy_ignore_headers Cache-Control;
+    proxy_cache_valid 60m;
+    proxy_pass http://daedong_upstream;
+  }
+
+  # 서버
+  location / {
+    proxy_pass http://daedong_upstream;
+  }
+}


### PR DESCRIPTION
## Deployed URL

- https://www.daedongyeomap.com/
- 80 포트로 접근시`redirect` 설정해뒀는데 실수로 `host` 이름 넣는 거 빼먹었다. 다음에 배포할 때 적용함

## Description

- `computing resource`: `ncp`
    - cpu 1
    - memory 2GB
    - SSD 40GB (nginx 돌릴 예정인데다가, HDD랑 가격차이 크지 않아서 SSD로 생성함)
- `reverse-proxy`: `nginx`
    - `gzip`
    - `ssl proxy`
    - 사용한 캐시정책은 설정파일에 주석으로 남겨둠
- `container runtime`: `docker`
- `container management`: `docker-compose`
- `ssl`: `letsencrypt`

## To Reviewer

> 인프라 이처럼 설정한 이유 쭉 적어뒀는데, 혹시 더 좋은 방식 있으면 알려주면 너무 좋습니다
> 고려사항: 쿠버네티스 도입 이전에 사용할 방식 & 하나의 인스턴스로 사용할 방식

1. `ncp` 쪽에 남은 크레딧이 조금 있어서, 일단 아래 스펙으로 인스턴스 생성함
2. `vercel app` 앞단에 `nginx`로 리버스 프록시만 올릴까 했었는데, `staging` 서버랑 `real` 서버는 분리하는게 좋을 것 같아서 이처럼 구성했음
    - 팀마다 다를 것 같긴한데, `git`과 `real`서버를 바로 `cd` 연동시켜두는 경우는 못 본 것 같아서
3. 지금 사용자도 없는데 서버 리소스를 분리할 필요는 없을 것 같았음
    - 그래서 일단 컨테이너만 격리하고 `docker-compose` 이용하는 방식으로 설정해둠
4. ssl은 `certbot` 이용해서 수동으로 인증서 발급 받아서 적용한 상태임. `2021/05/11`에 만료 예정
    - 이거는 굳이 지금 자동화 하기보다, 만약에 서비스 유지해나가면 별도 `ssl tunneling` 하는 클라우드 리소스 받아서 연결시키는게 낫지 않을까 싶음
5. `config volume`은 따로 빼는게 좋을 것 같긴한데, 일단은 기능개발 빨리 해야 할 것 같아서 수동으로 넣어둠
    - 그래서 지금 이미지 빌드해서 도커헙에 올려둘수는 없는 상황 (시크릿키 같은게 이미지 안에 다 들어가는 상황이라)
    - 수동으로 인스턴스 접속해서 `git pull & docker-compose up` 해야 함